### PR TITLE
Fix exception where IEnumerable could be null

### DIFF
--- a/src/UNRVLD.ODP.VisitorGroups/REST/CustomerPropertyListRetriever.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/REST/CustomerPropertyListRetriever.cs
@@ -40,7 +40,7 @@ namespace UNRVLD.ODP.VisitorGroups.REST
 
             if (apiResult == null || !apiResult.Any())
             {
-                return null;
+                return Enumerable.Empty<Field>();
             }
 
             _cache.Insert(
@@ -52,7 +52,7 @@ namespace UNRVLD.ODP.VisitorGroups.REST
             return apiResult;
         }
 
-        private IEnumerable<Field> GetCustomerPropertiesRequest()
+        private ICollection<Field> GetCustomerPropertiesRequest()
         {
             try
             {
@@ -61,11 +61,11 @@ namespace UNRVLD.ODP.VisitorGroups.REST
 
                 var response = _restClient.GetAsync<CustomerFieldsResponse>(request).Result;
 
-                return response?.fields ?? Enumerable.Empty<Field>();
+                return response?.fields ?? Array.Empty<Field>();
             }
             catch
             {
-                return Enumerable.Empty<Field>();
+                return Array.Empty<Field>();
             }
         }
 

--- a/src/UNRVLD.ODP.VisitorGroups/REST/Models/CustomerFieldsResponse.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/REST/Models/CustomerFieldsResponse.cs
@@ -5,6 +5,6 @@ namespace UNRVLD.ODP.VisitorGroups.REST.Models
 {
     public class CustomerFieldsResponse
     {
-        public List<Field> fields { get; set; }
+        public ICollection<Field> fields { get; set; }
     }
 }


### PR DESCRIPTION
This PR fixes a scenario where GetCustomerProperties could return an IEnumerable that were null, causing a NullReferenceException. The solution suggested is to never return a null-Enumerable, but instead an empty ICollection.