### PR TITLE
Remove the dynamic customer query

### DIFF
--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/CustomerPropertyNumberCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/CustomerPropertyNumberCriterion.cs
@@ -1,6 +1,7 @@
 ﻿using EPiServer.Personalization.VisitorGroups;
 
 using System.Security.Principal;
+using Newtonsoft.Json.Linq;
 using UNRVLD.ODP.VisitorGroups.Criteria.Models;
 
 #if NET5_0_OR_GREATER
@@ -51,31 +52,26 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
 
                 if (!string.IsNullOrEmpty(vuidValue))
                 {
-                    var customer = _customerDataRetriever.GetCustomerInfoDynamic(vuidValue);
+                    var customer = _customerDataRetriever.GetCustomerInfo(vuidValue);
                     if (customer == null)
                     {
                         return false;
                     }
-
-                    var isMatch = false;
-
-                    var rawValue = (customer[Model.PropertyName] as Newtonsoft.Json.Linq.JValue)?.Value;
-                    if (rawValue != null)
+                    
+                    if (!customer.AdditionalFields.TryGetValue(Model.PropertyName, out var propertyToken))
                     {
-                        decimal propertyValue;
-                        if (decimal.TryParse(rawValue.ToString(), out propertyValue))
-                        {
-                            isMatch = CompareMe(propertyValue, Model.Comparison);
-                        }
+                        return false;
                     }
 
-                    return isMatch;
+                    return decimal.TryParse(propertyToken?.Value<string>(), out var propertyValue) &&
+                           CompareMe(propertyValue, Model.Comparison);
                 }
             }
             catch
             {
                 return false;
             }
+
             return false;
         }
 

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/ICustomerDataRetriever.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/ICustomerDataRetriever.cs
@@ -5,7 +5,5 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
     public interface ICustomerDataRetriever
     { 
         Customer GetCustomerInfo(string vuidValue);
-
-        dynamic GetCustomerInfoDynamic(string vuidValue);
     }
 }

--- a/src/UNRVLD.ODP.VisitorGroups/GraphQL/Models/Customer.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/GraphQL/Models/Customer.cs
@@ -1,4 +1,6 @@
-﻿using Newtonsoft.Json;
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace UNRVLD.ODP.VisitorGroups.GraphQL.Models
 {
@@ -12,6 +14,9 @@ namespace UNRVLD.ODP.VisitorGroups.GraphQL.Models
 
         [JsonProperty("audiences")]
         public GraphQL.Edges<Audience> Response { get; set; }
+
+        [JsonExtensionData]
+        public IDictionary<string, JToken> AdditionalFields { get; set; } = new Dictionary<string, JToken>();
     }
 
     public class Insights
@@ -27,11 +32,11 @@ namespace UNRVLD.ODP.VisitorGroups.GraphQL.Models
     public class Observations
     {
         [JsonProperty("total_revenue")]
-        public decimal TotalRevenue { get; set; }
+        public decimal? TotalRevenue { get; set; }
         [JsonProperty("order_count")]
-        public int OrderCount { get; set; }
+        public int? OrderCount { get; set; }
         [JsonProperty("AverageOrderRevenue")]
-        public decimal AverageOrderRevenue { get; set; }
+        public decimal? AverageOrderRevenue { get; set; }
     }
 
 }


### PR DESCRIPTION
This PR remove one of the two customer data GraphQL queries. Specifically the one that returns a dynamic ExpandoObject. Instead the typed method now uses the AdditionalData bucket property to hold all the customer properties.

When there is only one query, only one cache entry will be stored. So if there are more than one criteria to evaluate, it all becomes more efficient.