### PR TITLE
Fix resolving of endpoint

### DIFF
--- a/.github/workflows/build-visitor-groups.yml
+++ b/.github/workflows/build-visitor-groups.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.0.0.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.0.0-rc.${{ github.run_number }} 
+  BUILD_NO: 2.0.1.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.0.1-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/StandardPrefixer.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/StandardPrefixer.cs
@@ -5,12 +5,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
 {
     public class StandardPrefixer : IPrefixer
     {
-        private readonly Regex prefixRegex;
-
-        public StandardPrefixer()
-        {
-            prefixRegex = new Regex(@"^\[(.+)\] - (.+)$", RegexOptions.Compiled);
-        }
+        private static readonly Regex PrefixRegex = new(@"^\[(.+)\] - (.+)$", RegexOptions.Compiled);
 
         public string Prefix(string value, string prefix)
         {
@@ -19,7 +14,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
 
         public (string? prefix, string value) SplitPrefix(string value)
         {
-            var match = prefixRegex.Match(value);
+            var match = PrefixRegex.Match(value);
 
             return match.Success ? (match.Groups[1].Value, match.Groups[2].Value) : (null, value);
         }

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/StandardPrefixer.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/StandardPrefixer.cs
@@ -21,7 +21,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
         {
             var match = prefixRegex.Match(value);
 
-            return match.Success ? (match.Groups[1].Value, match.Groups[2].Value) : (string.Empty, value);
+            return match.Success ? (match.Groups[1].Value, match.Groups[2].Value) : (null, value);
         }
     }
 }

--- a/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
+++ b/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<PackageId>UNRVLD.ODP.VisitorGroups</PackageId>
 		<RepositoryUrl>https://github.com/made-to-engage/ODP.VisitorGroups</RepositoryUrl>
-		<Version>2.0.0</Version>
+		<Version>2.0.1</Version>
 		<Authors>Andrew Markham; David Knipe</Authors>
 		<Owners>Made to Engage;UNRVLD</Owners>
 		<Title>UNRVLD - Optimizely Visitor Groups</Title>


### PR DESCRIPTION
If we don't use a specific endpoint, and would instead need the first endpoint, nothing is selected.

This is because the first in list is only selected if `endpointKey` is null. However, in `StandardPrefixer` the default is `string.Empty`.

This PR changes the default value to null, to enable the mentioned logic. Besides this, the PR also makes the Regex expression static to highlight its singleton nature.