### PR TITLE
Feature/allow custom odp query

### DIFF
--- a/.github/workflows/build-visitor-groups.yml
+++ b/.github/workflows/build-visitor-groups.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.2.0.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.2.0-rc.${{ github.run_number }} 
+  BUILD_NO: 2.2.1.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.2.1-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/.github/workflows/build-visitor-groups.yml
+++ b/.github/workflows/build-visitor-groups.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 env:
-  BUILD_NO: 2.2.1.${{ github.run_number }}  
-  BUILD_NO_PRE: 2.2.1-rc.${{ github.run_number }} 
+  BUILD_NO: 2.3.0.${{ github.run_number }}  
+  BUILD_NO_PRE: 2.3.0-rc.${{ github.run_number }} 
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ All settings are optional, apart from the PrivateApiKey
       //Other config
     "OdpVisitorGroupOptions": {
         "OdpCookieName": "vuid",
+        "OdpIdQueryField": "vuid",
         "CacheTimeoutSeconds": 10,
         "SchemaCacheTimeoutSeconds": 86400,
         "PopulationEstimateCacheTimeoutSeconds": 4320,
@@ -82,3 +83,4 @@ All settings are optional, apart from the PrivateApiKey
  |2.1.0|Added support to get vuid from httprequest, this supports content delivery api |
  |2.1.1|Fixed bug with HTTPClient instantiation |
  |2.2.0|Updated RestSharp veersion to 112.1.0 to address security vulnerability |
+ |2.2.1|Added support to set ODP ID field to query via OdpIdQueryField config value |

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ All settings are optional, apart from the PrivateApiKey
  |2.1.0|Added support to get vuid from httprequest, this supports content delivery api |
  |2.1.1|Fixed bug with HTTPClient instantiation |
  |2.2.0|Updated RestSharp veersion to 112.1.0 to address security vulnerability |
- |2.2.1|Added support to set ODP ID field to query via OdpIdQueryField config value |
+ |2.3.0|Added support to set ODP ID field to query via OdpIdQueryField config value |

--- a/src/DemoSite/appsettings.Development.json
+++ b/src/DemoSite/appsettings.Development.json
@@ -26,6 +26,7 @@
     },
     "OdpVisitorGroupOptions": {
         "OdpCookieName": "vuid",
+        "OdpIdQueryField": "vuid",
         "CacheTimeoutSeconds": 10,
         "SchemaCacheTimeoutSeconds": 86400,
         "PopulationEstimateCacheTimeoutSeconds": 4320,

--- a/src/UNRVLD.ODP.VisitorGroups/Configuration/OdpVisitorGroupOptions.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Configuration/OdpVisitorGroupOptions.cs
@@ -14,6 +14,7 @@ namespace UNRVLD.ODP.VisitorGroups.Configuration
     ///        //Other config
     ///        "OdpVisitorGroupOptions": {
     ///            "OdpCookieName": "vuid",
+    ///            "OdpIdQueryField": "vuid",
     ///            "CacheTimeoutSeconds": 10,
     ///            "SchemaCacheTimeoutSeconds": 86400,
     ///            "PopulationEstimateCacheTimeoutSeconds": 4320,
@@ -38,6 +39,7 @@ namespace UNRVLD.ODP.VisitorGroups.Configuration
         public OdpVisitorGroupOptions()
         {
             OdpCookieName = "vuid";
+            OdpIdQueryField = "vuid";
             CacheTimeoutSeconds = 1;
             OdpEndpoints = [];
             SchemaCacheTimeoutSeconds = 86400;
@@ -47,6 +49,10 @@ namespace UNRVLD.ODP.VisitorGroups.Configuration
         /// The cookie name of the ODP cookie, should nearly always be "vuid"
         /// </summary>
         public string OdpCookieName { get; set; }
+        /// <summary>
+        /// The ODP query field used to query the cookie value, should nearly always be "vuid"
+        /// </summary>
+        public string OdpIdQueryField { get; set; }
         /// <summary>
         /// The length of time to micro-cache responses for, used to avoid multiple API hits in a single request
         /// </summary>

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/AudienceCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/AudienceCriterion.cs
@@ -33,7 +33,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
                 {
                     var splitPrefix = _prefixer.SplitPrefix(Model.Audience);
 
-                    return _customerDataRetriever.IsInAudience(vuidValue, OptionValues.OdpIdQueryField, splitPrefix.prefix);
+                    return _customerDataRetriever.IsInAudience(vuidValue, OptionValues.OdpIdQueryField, splitPrefix.value, splitPrefix.prefix);
                 }
                 else
                 {

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/AudienceCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/AudienceCriterion.cs
@@ -32,12 +32,12 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
                 if (OptionValues.HasMultipleEndpoints)
                 {
                     var splitPrefix = _prefixer.SplitPrefix(Model.Audience);
-                
-                    return _customerDataRetriever.IsInAudience(vuidValue,  splitPrefix.value, splitPrefix.prefix);
-                } 
+
+                    return _customerDataRetriever.IsInAudience(vuidValue, OptionValues.OdpIdQueryField, splitPrefix.prefix);
+                }
                 else
                 {
-                    return _customerDataRetriever.IsInAudience(vuidValue, Model.Audience);
+                    return _customerDataRetriever.IsInAudience(vuidValue, OptionValues.OdpIdQueryField, Model.Audience);
                 }
             }
             catch
@@ -45,6 +45,6 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
                 return false;
             }
         }
- 
+
     }
 }

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/CustomerPropertyNumberCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/CustomerPropertyNumberCriterion.cs
@@ -21,7 +21,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
                                                ICustomerDataRetriever customerDataRetriever,
                                                IODPUserProfile odpUserProfile,
                                                IPrefixer prefixer)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
             _prefixer = prefixer;
@@ -33,7 +33,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
             {
                 var splitPrefix = _prefixer.SplitPrefix(Model.PropertyName);
 
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, splitPrefix.prefix);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, splitPrefix.prefix);
                 if (customer == null)
                 {
                     return false;
@@ -46,7 +46,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
 
                 return decimal.TryParse(propertyToken?.Value<string>(), out var propertyValue) &&
                         CompareMe(propertyValue, Model.Comparison);
-                
+
             }
             catch
             {

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/CustomerPropertyTextCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/CustomerPropertyTextCriterion.cs
@@ -21,7 +21,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
             ICustomerDataRetriever customerDataRetriever,
             IODPUserProfile odpUserProfile,
             IPrefixer prefixer)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
             _prefixer = prefixer;
@@ -33,7 +33,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
             {
                 var splitPrefix = _prefixer.SplitPrefix(Model.PropertyName);
 
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, splitPrefix.prefix);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, splitPrefix.prefix);
                 if (customer == null)
                 {
                     return false;

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/EngagementRankCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/EngagementRankCriterion.cs
@@ -17,7 +17,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         public EngagementRankCriterion(OdpVisitorGroupOptions optionValues,
                 ICustomerDataRetriever customerDataRetriever,
                 IODPUserProfile odpUserProfile)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
         }
@@ -26,7 +26,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         {
             try
             {
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, Model.InstanceName);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, Model.InstanceName);
 
                 return CompareMe(customer?.Insights?.EngagementRank, Model.Comparison);
             }

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/ObservationCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/ObservationCriterion.cs
@@ -20,7 +20,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         public ObservationCriterion(OdpVisitorGroupOptions optionValues,
                             ICustomerDataRetriever customerDataRetriever,
                             IODPUserProfile odpUserProfile)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
         }
@@ -29,7 +29,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         {
             try
             {
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, Model.InstanceName);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, Model.InstanceName);
 
                 var isMatch = false;
                 switch (Model.Observation)
@@ -46,7 +46,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
                 }
 
                 return isMatch;
-                
+
             }
             catch
             {

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/OrderLikelihoodCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/OrderLikelihoodCriterion.cs
@@ -19,7 +19,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         public OrderLikelihoodCriterion(OdpVisitorGroupOptions optionValues,
                                         ICustomerDataRetriever customerDataRetriever,
                                         IODPUserProfile odpUserProfile)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
         }
@@ -28,10 +28,10 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         {
             try
             {
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, Model.InstanceName);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, Model.InstanceName);
 
                 return customer?.Insights?.OrderLikelihood == Model.OrderLikelihood;
-            
+
             }
             catch
             {

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/WinbackZoneCriterion.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/Criterion/WinbackZoneCriterion.cs
@@ -18,7 +18,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         public WinbackZoneCriterion(OdpVisitorGroupOptions optionValues,
                             ICustomerDataRetriever customerDataRetriever,
                             IODPUserProfile odpUserProfile)
-            : base(optionValues,odpUserProfile)
+            : base(optionValues, odpUserProfile)
         {
             _customerDataRetriever = customerDataRetriever;
         }
@@ -27,7 +27,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria.Criterion
         {
             try
             {
-                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, Model.InstanceName);
+                var customer = _customerDataRetriever.GetCustomerInfo(vuidValue, OptionValues.OdpIdQueryField, Model.InstanceName);
 
                 return customer?.Insights?.WinbackZone == Model.WinbackZone;
             }

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/CustomerDataRetriever.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/CustomerDataRetriever.cs
@@ -35,7 +35,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
             _prefixer = prefixer;
         }
 
-        public Customer? GetCustomerInfo(string vuidValue, string? endpointKey = null)
+        public Customer? GetCustomerInfo(string vuidValue, string OdpIdQueryField, string? endpointKey = null)
         {
             try
             {
@@ -53,10 +53,10 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
 
                 var allFields = _customerPropertyListRetriever.GetCustomerProperties(endpointKey);
 
-                var allFieldsString = string.Join(Environment.NewLine, allFields.Select(x =>  _prefixer.SplitPrefix(x.Name).value));
+                var allFieldsString = string.Join(Environment.NewLine, allFields.Select(x => _prefixer.SplitPrefix(x.Name).value));
 
                 var query = $@"query MyQuery {{
-                                  customer(vuid: ""{vuidValue}"") {{
+                                  customer({OdpIdQueryField}: ""{vuidValue}"") {{
                                     {allFieldsString}
                                     observations {{
                                       total_revenue
@@ -71,7 +71,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
                                   }}
                                 }}";
 
-                Customer? customer =  null;
+                Customer? customer = null;
                 var odpEndPoint = _optionValues.GetEndpoint(endpointKey);
 
                 if (odpEndPoint != null)
@@ -101,7 +101,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
             }
         }
 
-        public bool IsInAudience(string vuidValue, string audience, string? endpointKey = null)
+        public bool IsInAudience(string vuidValue, string OdpIdQueryField, string audience, string? endpointKey = null)
         {
             try
             {
@@ -113,7 +113,7 @@ namespace UNRVLD.ODP.VisitorGroups.Criteria
                 }
 
                 var query = $@"query MyQuery {{
-                                      customer(vuid: ""{vuidValue}"") {{
+                                      customer({OdpIdQueryField}: ""{vuidValue}"") {{
                                         audiences (subset: [""{audience}""]) {{
                                           edges {{
                                             node {{

--- a/src/UNRVLD.ODP.VisitorGroups/Criteria/ICustomerDataRetriever.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/Criteria/ICustomerDataRetriever.cs
@@ -3,9 +3,9 @@
 namespace UNRVLD.ODP.VisitorGroups.Criteria
 {
     public interface ICustomerDataRetriever
-    { 
-        Customer? GetCustomerInfo(string vuidValue, string? endpointKey = null);
+    {
+        Customer? GetCustomerInfo(string vuidValue, string OdpIdQueryField, string? endpointKey = null);
 
-        bool IsInAudience(string vuidValue, string audience, string? endpointKey = null);
+        bool IsInAudience(string vuidValue, string OdpIdQueryField, string audience, string? endpointKey = null);
     }
 }

--- a/src/UNRVLD.ODP.VisitorGroups/ODPUserProfile.cs
+++ b/src/UNRVLD.ODP.VisitorGroups/ODPUserProfile.cs
@@ -25,9 +25,13 @@ namespace UNRVLD.ODP.VisitorGroups
 
         private string? GetVuidValueInternal(string? vuidValue)
         {
-            if (!string.IsNullOrWhiteSpace(vuidValue) && vuidValue.Length > 35)
+            if (_optionValues.OdpCookieName == "vuid" && !string.IsNullOrWhiteSpace(vuidValue) && vuidValue.Length > 35)
             {
                 return vuidValue[..36].Replace("-", string.Empty);
+            }
+            else if (!string.IsNullOrWhiteSpace(vuidValue))
+            {
+                return vuidValue;
             }
 
             return null;

--- a/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
+++ b/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<PackageId>UNRVLD.ODP.VisitorGroups</PackageId>
 		<RepositoryUrl>https://github.com/made-to-engage/ODP.VisitorGroups</RepositoryUrl>
-		<Version>2.2.0</Version>
+		<Version>2.2.1</Version>
 		<Authors>Andrew Markham; David Knipe</Authors>
 		<Owners>Made to Engage;UNRVLD</Owners>
 		<Title>UNRVLD - Optimizely Visitor Groups</Title>
@@ -27,6 +27,7 @@
 		  2.1.0 - Added support to get vuid from httprequest, this supports content delivery api
 		  2.1.1 - Fixed bug with HTTPClient instantiation
 		  2.2.0 - Updated RestSharp veersion to 112.1.0 to address security vulnerability
+		  2.2.1 - Added support to set ODP ID field to query via OdpIdQueryField config value
 	  </ReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
+++ b/src/UNRVLD.ODP.VisitorGroups/UNRVLD.ODP.VisitorGroups.csproj
@@ -4,7 +4,7 @@
 		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
 		<PackageId>UNRVLD.ODP.VisitorGroups</PackageId>
 		<RepositoryUrl>https://github.com/made-to-engage/ODP.VisitorGroups</RepositoryUrl>
-		<Version>2.2.1</Version>
+		<Version>2.3.0</Version>
 		<Authors>Andrew Markham; David Knipe</Authors>
 		<Owners>Made to Engage;UNRVLD</Owners>
 		<Title>UNRVLD - Optimizely Visitor Groups</Title>
@@ -27,7 +27,7 @@
 		  2.1.0 - Added support to get vuid from httprequest, this supports content delivery api
 		  2.1.1 - Fixed bug with HTTPClient instantiation
 		  2.2.0 - Updated RestSharp veersion to 112.1.0 to address security vulnerability
-		  2.2.1 - Added support to set ODP ID field to query via OdpIdQueryField config value
+		  2.3.0 - Added support to set ODP ID field to query via OdpIdQueryField config value
 	  </ReleaseNotes>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Adds ability to set ODP field to be queried per https://github.com/unrvld/ODP.VisitorGroups/issues/26

Key changes:
- New env var: OdpIdQueryField (default: "vuid")
- Update CustomerDataRetriever.cs queries to query on OdpIdQueryField instead of hardcoding to "vuid"
- Update ODPUserProfile.cs to only manipulate value of ID retrieved from cookie if using standard ODP "vuid" cookie
