### PR TITLE
Add link to Opti docs for BaseEndPoint URLs for different regions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ services.AddODPVisitorGroups();
 
 *appsettings.json*
 All settings are optional, apart from the PrivateApiKey
+
+Note: refer to [Optimizely's documentation](https://docs.developers.optimizely.com/optimizely-data-platform/reference/introduction#rest-api) for correct BaseEndPoint value for different ODP regions. Values below are examples.
+
 ``` json
 {
    "EPiServer": {


### PR DESCRIPTION
Adds link in README to Opti docs for BaseEndPoint URLs for different regions, to avoid confusion.